### PR TITLE
Add LuckyWeb::Exposeable

### DIFF
--- a/spec/lucky_web/expose_spec.cr
+++ b/spec/lucky_web/expose_spec.cr
@@ -1,0 +1,80 @@
+require "../spec/spec_helper"
+
+class OnlyExpose < LuckyWeb::Action
+  include LuckyWeb::Exposeable
+
+  expose :name
+
+  get "/expose" do
+    render
+    render OnlyExposePage
+  end
+
+  def name
+    "Paul"
+  end
+end
+
+class OnlyExposePage
+  include LuckyWeb::Page
+
+  assign name : String
+
+  render do
+  end
+end
+
+abstract class InheritedExposureAction < LuckyWeb::Action
+  include LuckyWeb::Exposeable
+
+  macro inherited
+    expose :expose_one
+  end
+
+  def expose_one
+    "expose_one"
+  end
+end
+
+class MultipleExposeAndAssigns < InheritedExposureAction
+  expose :expose_two
+
+  get "/mutli-expose" do
+    render arg1: "arg1", arg2: "arg2"
+    render MultipleExposeAndAssignsPage, arg1: "arg1", arg2: "arg2"
+  end
+
+  def expose_two
+    "expose_two"
+  end
+end
+
+class MultipleExposeAndAssignsPage
+  include LuckyWeb::Page
+
+  assign expose_one : String
+  assign expose_two : String
+  assign arg1 : String
+  assign arg2 : String
+
+  render do
+  end
+end
+
+describe "exposures" do
+  it "works without explicit assigns" do
+    OnlyExpose.new(context, params).call
+    MultipleExposeAndAssigns.new(context, params).call
+  end
+end
+
+private def context(path = "/")
+  io = IO::Memory.new
+  request = HTTP::Request.new("GET", path)
+  response = HTTP::Server::Response.new(io)
+  HTTP::Server::Context.new request, response
+end
+
+private def params
+  {} of String => String
+end

--- a/src/lucky_web/action.cr
+++ b/src/lucky_web/action.cr
@@ -1,3 +1,5 @@
+require "./*"
+
 abstract class LuckyWeb::Action
   getter :context, :path_params
 
@@ -5,6 +7,8 @@ abstract class LuckyWeb::Action
   end
 
   abstract def call : LuckyWeb::Response
+
+  EXPOSURES = [] of Symbol
 
   macro inherited
     include LuckyWeb::Routeable

--- a/src/lucky_web/exposable.cr
+++ b/src/lucky_web/exposable.cr
@@ -1,0 +1,13 @@
+module LuckyWeb::Exposeable
+  macro included
+    EXPOSURES = [] of Symbol
+
+    macro inherited
+      EXPOSURES = [] of Symbol
+    end
+  end
+
+  macro expose(method_name)
+    {% EXPOSURES << method_name.id %}
+  end
+end

--- a/src/lucky_web/renderable.cr
+++ b/src/lucky_web/renderable.cr
@@ -4,6 +4,9 @@ module LuckyWeb::Renderable
       {% for key, value in assigns %}
         {{ key }}: {{ value }},
       {% end %}
+      {% for key in EXPOSURES %}
+        {{ key }}: {{ key }},
+      {% end %}
     )
     body = view.render.to_s
     LuckyWeb::Response.new(context, "text/html", body)
@@ -13,6 +16,9 @@ module LuckyWeb::Renderable
     view = {{ "#{@type.name}Page".id }}.new(
       {% for key, value in assigns %}
         {{ key }}: {{ value }},
+      {% end %}
+      {% for key in EXPOSURES %}
+        {{ key }}: {{ key }},
       {% end %}
     )
     body = view.render.to_s


### PR DESCRIPTION
Closes #51

I don't like that you need to include it. I'm trying to figure out if
there's a better way to do this so you can inherit exposures, but I
can't think of anything quite yet.

I could have made it a module like LuckyWeb::Page, but then the problem
is that in LuckyWeb::Route I can't restrict by a module type e.g.
`LuckyWeb::Action.module`. This is a bit of a bummer. For now I'll move
forward with this and hopefully I can figure out a better solution in
the future.