### PR TITLE
Fix pages breaking `lucky` command

### DIFF
--- a/src/app/pages/tasks/index_page.cr
+++ b/src/app/pages/tasks/index_page.cr
@@ -1,4 +1,6 @@
-class Tasks::IndexPage < LuckyWeb::Page
+class Tasks::IndexPage
+  include LuckyWeb::Page
+
   needs tasks : Array(Task)
 
   render do

--- a/src/app/pages/tasks/new_page.cr
+++ b/src/app/pages/tasks/new_page.cr
@@ -1,4 +1,6 @@
-class Tasks::NewPage < LuckyWeb::Page
+class Tasks::NewPage
+  include LuckyWeb::Page
+
   render do
     header({class: "WHAT"}) do
       text "New HTML"


### PR DESCRIPTION
When trying to run `lucky` an error was thrown since `Tasks::NewPage`
and `Tasks::IndexPage` were trying to inherit from `LuckyWeb::Page`
which is a model and not a class.

This resolves the issue by replacing inheritance with `include
LuckyWeb::Page`

I'm assuming we want to `include` here instead of turning `LuckyWeb::Page` into a class.