### PR TITLE
Replace text helper trailing space with newline

### DIFF
--- a/spec/lucky_web/base_tags_spec.cr
+++ b/spec/lucky_web/base_tags_spec.cr
@@ -9,7 +9,7 @@ end
 
 describe LuckyWeb::BaseTags do
   it "renders para tag as <p>" do
-    view.para("foo").to_s.should contain "<p>foo </p>"
+    view.para("foo").to_s.should contain "<p>\nfoo\n</p>"
   end
 end
 

--- a/spec/lucky_web/base_tags_spec.cr
+++ b/spec/lucky_web/base_tags_spec.cr
@@ -9,7 +9,7 @@ end
 
 describe LuckyWeb::BaseTags do
   it "renders para tag as <p>" do
-    view.para("foo").to_s.should contain "<p>\nfoo\n</p>"
+    view.para("foo").to_s.should contain "<p>foo</p>"
   end
 end
 

--- a/spec/lucky_web/form_helpers_spec.cr
+++ b/spec/lucky_web/form_helpers_spec.cr
@@ -46,7 +46,7 @@ end
 describe LuckyWeb::FormHelpers do
   it "renders a form tag" do
     view.inferred_put_form.to_s.should contain <<-HTML
-    <form action="/form_helpers/fake_id" method="post"><input type="hidden" name="_method" value="put"/> foo</form>
+    <form action="/form_helpers/fake_id" method="post"><input type="hidden" name="_method" value="put"/>foo</form>
     HTML
 
     view.inferred_post_form.to_s.should contain <<-HTML

--- a/spec/lucky_web/form_helpers_spec.cr
+++ b/spec/lucky_web/form_helpers_spec.cr
@@ -46,19 +46,19 @@ end
 describe LuckyWeb::FormHelpers do
   it "renders a form tag" do
     view.inferred_put_form.to_s.should contain <<-HTML
-    <form action="/form_helpers/fake_id" method="post"><input type="hidden" name="_method" value="put"/> foo </form>
+    <form action="/form_helpers/fake_id" method="post"><input type="hidden" name="_method" value="put"/> \nfoo\n</form>
     HTML
 
     view.inferred_post_form.to_s.should contain <<-HTML
-    <form action="/form_helpers" method="post">foo </form>
+    <form action="/form_helpers" method="post">\nfoo\n</form>
     HTML
 
     view.inferred_get_form.to_s.should contain <<-HTML
-    <form action="/form_helpers" method="get">foo </form>
+    <form action="/form_helpers" method="get">\nfoo\n</form>
     HTML
 
     view.form_with_html_options.to_s.should contain <<-HTML
-    <form action="/form_helpers" method="post" class="cool-form">foo </form>
+    <form action="/form_helpers" method="post" class="cool-form">\nfoo\n</form>
     HTML
 
     form = view.form_for(FormHelpers::Index) { }

--- a/spec/lucky_web/form_helpers_spec.cr
+++ b/spec/lucky_web/form_helpers_spec.cr
@@ -46,19 +46,19 @@ end
 describe LuckyWeb::FormHelpers do
   it "renders a form tag" do
     view.inferred_put_form.to_s.should contain <<-HTML
-    <form action="/form_helpers/fake_id" method="post"><input type="hidden" name="_method" value="put"/> \nfoo\n</form>
+    <form action="/form_helpers/fake_id" method="post"><input type="hidden" name="_method" value="put"/> foo</form>
     HTML
 
     view.inferred_post_form.to_s.should contain <<-HTML
-    <form action="/form_helpers" method="post">\nfoo\n</form>
+    <form action="/form_helpers" method="post">foo</form>
     HTML
 
     view.inferred_get_form.to_s.should contain <<-HTML
-    <form action="/form_helpers" method="get">\nfoo\n</form>
+    <form action="/form_helpers" method="get">foo</form>
     HTML
 
     view.form_with_html_options.to_s.should contain <<-HTML
-    <form action="/form_helpers" method="post" class="cool-form">\nfoo\n</form>
+    <form action="/form_helpers" method="post" class="cool-form">foo</form>
     HTML
 
     form = view.form_for(FormHelpers::Index) { }

--- a/spec/lucky_web/input_helpers_spec.cr
+++ b/spec/lucky_web/input_helpers_spec.cr
@@ -138,11 +138,11 @@ describe LuckyWeb::InputHelpers do
 
   it "renders textareas" do
     view.textarea(form.first_name).to_s.should contain <<-HTML
-    <textarea name="user:first_name">My name </textarea>
+    <textarea name="user:first_name">\nMy name\n</textarea>
     HTML
 
     view.textarea(form.first_name, class: "cool").to_s.should contain <<-HTML
-    <textarea name="user:first_name" class="cool">My name </textarea>
+    <textarea name="user:first_name" class="cool">\nMy name\n</textarea>
     HTML
   end
 end

--- a/spec/lucky_web/input_helpers_spec.cr
+++ b/spec/lucky_web/input_helpers_spec.cr
@@ -138,11 +138,11 @@ describe LuckyWeb::InputHelpers do
 
   it "renders textareas" do
     view.textarea(form.first_name).to_s.should contain <<-HTML
-    <textarea name="user:first_name">\nMy name\n</textarea>
+    <textarea name="user:first_name">My name</textarea>
     HTML
 
     view.textarea(form.first_name, class: "cool").to_s.should contain <<-HTML
-    <textarea name="user:first_name" class="cool">\nMy name\n</textarea>
+    <textarea name="user:first_name" class="cool">My name</textarea>
     HTML
   end
 end

--- a/spec/lucky_web/label_helpers_spec.cr
+++ b/spec/lucky_web/label_helpers_spec.cr
@@ -40,11 +40,11 @@ end
 describe LuckyWeb::LabelHelpers do
   it "renders a label tag" do
     view.label_without_html_options.to_s.should contain <<-HTML
-    <label>First name </label>
+    <label>\nFirst name\n</label>
     HTML
 
     view.label_with_html_options.to_s.should contain <<-HTML
-    <label class="best-label">First name </label>
+    <label class="best-label">\nFirst name\n</label>
     HTML
   end
 end

--- a/spec/lucky_web/label_helpers_spec.cr
+++ b/spec/lucky_web/label_helpers_spec.cr
@@ -40,11 +40,11 @@ end
 describe LuckyWeb::LabelHelpers do
   it "renders a label tag" do
     view.label_without_html_options.to_s.should contain <<-HTML
-    <label>\nFirst name\n</label>
+    <label>First name</label>
     HTML
 
     view.label_with_html_options.to_s.should contain <<-HTML
-    <label class="best-label">\nFirst name\n</label>
+    <label class="best-label">First name</label>
     HTML
   end
 end

--- a/spec/lucky_web/link_helpers_spec.cr
+++ b/spec/lucky_web/link_helpers_spec.cr
@@ -49,19 +49,19 @@ end
 
 describe LuckyWeb::LinkHelpers do
   it "renders a link tag" do
-    view.get_route.to_s.should contain %(<a href="/link_helpers">Test </a> )
-    view.non_get_route.to_s.should contain %(<a href="/link_helpers" data-method="post">Test </a> )
+    view.get_route.to_s.should contain %(<a href="/link_helpers">\nTest\n</a> )
+    view.non_get_route.to_s.should contain %(<a href="/link_helpers" data-method="post">\nTest\n</a> )
     view
       .non_get_route_with_options
       .to_s
-      .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">Test </a> )
-    view.string_path.to_s.should contain %(<a href="/foos">Test </a> )
-    view.string_path_with_options.to_s.should contain %(<a href="/foos" data-method="post">Test </a> )
+      .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">\nTest\n</a> )
+    view.string_path.to_s.should contain %(<a href="/foos">\nTest\n</a> )
+    view.string_path_with_options.to_s.should contain %(<a href="/foos" data-method="post">\nTest\n</a> )
   end
 
   it "renders a link tag with an action" do
     view.link("Test", to: LinkHelpers::Index).to_s.should contain <<-HTML
-    <a href="/link_helpers">Test </a>
+    <a href="/link_helpers">\nTest\n</a>
     HTML
 
     link = view.link(to: LinkHelpers::Index, class: "link") { }
@@ -73,11 +73,11 @@ describe LuckyWeb::LinkHelpers do
 
   it "renders a link tag with a block" do
     view.string_path_with_block.to_s.should contain <<-HTML
-    <a href="/foo">Hello </a>
+    <a href="/foo">\nHello\n</a>
     HTML
 
     view.get_route_with_block.to_s.should contain <<-HTML
-    <a href="/link_helpers">Hello </a>
+    <a href="/link_helpers">\nHello\n</a>
     HTML
   end
 end

--- a/spec/lucky_web/link_helpers_spec.cr
+++ b/spec/lucky_web/link_helpers_spec.cr
@@ -49,19 +49,19 @@ end
 
 describe LuckyWeb::LinkHelpers do
   it "renders a link tag" do
-    view.get_route.to_s.should contain %(<a href="/link_helpers">\nTest\n</a> )
-    view.non_get_route.to_s.should contain %(<a href="/link_helpers" data-method="post">\nTest\n</a> )
+    view.get_route.to_s.should contain %(<a href="/link_helpers">Test</a> )
+    view.non_get_route.to_s.should contain %(<a href="/link_helpers" data-method="post">Test</a> )
     view
       .non_get_route_with_options
       .to_s
-      .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">\nTest\n</a> )
-    view.string_path.to_s.should contain %(<a href="/foos">\nTest\n</a> )
-    view.string_path_with_options.to_s.should contain %(<a href="/foos" data-method="post">\nTest\n</a> )
+      .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">Test</a> )
+    view.string_path.to_s.should contain %(<a href="/foos">Test</a> )
+    view.string_path_with_options.to_s.should contain %(<a href="/foos" data-method="post">Test</a> )
   end
 
   it "renders a link tag with an action" do
     view.link("Test", to: LinkHelpers::Index).to_s.should contain <<-HTML
-    <a href="/link_helpers">\nTest\n</a>
+    <a href="/link_helpers">Test</a>
     HTML
 
     link = view.link(to: LinkHelpers::Index, class: "link") { }
@@ -73,11 +73,11 @@ describe LuckyWeb::LinkHelpers do
 
   it "renders a link tag with a block" do
     view.string_path_with_block.to_s.should contain <<-HTML
-    <a href="/foo">\nHello\n</a>
+    <a href="/foo">Hello</a>
     HTML
 
     view.get_route_with_block.to_s.should contain <<-HTML
-    <a href="/link_helpers">\nHello\n</a>
+    <a href="/link_helpers">Hello</a>
     HTML
   end
 end

--- a/spec/lucky_web/link_helpers_spec.cr
+++ b/spec/lucky_web/link_helpers_spec.cr
@@ -49,14 +49,14 @@ end
 
 describe LuckyWeb::LinkHelpers do
   it "renders a link tag" do
-    view.get_route.to_s.should contain %(<a href="/link_helpers">Test</a> )
-    view.non_get_route.to_s.should contain %(<a href="/link_helpers" data-method="post">Test</a> )
+    view.get_route.to_s.should contain %(<a href="/link_helpers">Test</a>)
+    view.non_get_route.to_s.should contain %(<a href="/link_helpers" data-method="post">Test</a>)
     view
       .non_get_route_with_options
       .to_s
-      .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">Test</a> )
-    view.string_path.to_s.should contain %(<a href="/foos">Test</a> )
-    view.string_path_with_options.to_s.should contain %(<a href="/foos" data-method="post">Test</a> )
+      .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">Test</a>)
+    view.string_path.to_s.should contain %(<a href="/foos">Test</a>)
+    view.string_path_with_options.to_s.should contain %(<a href="/foos" data-method="post">Test</a>)
   end
 
   it "renders a link tag with an action" do

--- a/spec/lucky_web/page_spec.cr
+++ b/spec/lucky_web/page_spec.cr
@@ -64,13 +64,13 @@ end
 describe LuckyWeb::Page do
   describe "tags that contain contents" do
     it "can be called with various arguments" do
-      view.header("text").to_s.should eq %(<header>text </header> )
-      view.header("text", {class: "stuff"}).to_s.should eq %(<header class="stuff">text </header> )
-      view.header("text", class: "stuff").to_s.should eq %(<header class="stuff">text </header> )
+      view.header("text").to_s.should eq %(<header>\ntext\n</header> )
+      view.header("text", {class: "stuff"}).to_s.should eq %(<header class="stuff">\ntext\n</header> )
+      view.header("text", class: "stuff").to_s.should eq %(<header class="stuff">\ntext\n</header> )
     end
 
     it "dasherizes attribute names" do
-      view.header("text", data_foo: "stuff").to_s.should eq %(<header data-foo="stuff">text </header> )
+      view.header("text", data_foo: "stuff").to_s.should eq %(<header data-foo="stuff">\ntext\n</header> )
     end
   end
 
@@ -85,7 +85,7 @@ describe LuckyWeb::Page do
 
   describe "HTML escaping" do
     it "escapes text" do
-      UnsafePage.new.render.to_s.should eq "&lt;script&gt;not safe&lt;/span&gt; "
+      UnsafePage.new.render.to_s.should eq "\n&lt;script&gt;not safe&lt;/span&gt;\n"
     end
 
     it "escapes HTML attributes" do
@@ -107,8 +107,8 @@ describe LuckyWeb::Page do
 
   describe "can be used to render layouts" do
     it "renders layouts" do
-      InnerPage.new.render.to_s.should contain %(<title>A great title </title>)
-      InnerPage.new.render.to_s.should contain %(<body>Inner text </body>)
+      InnerPage.new.render.to_s.should contain %(<title>\nA great title\n</title>)
+      InnerPage.new.render.to_s.should contain %(<body>\nInner text\n</body>)
     end
   end
 end

--- a/spec/lucky_web/page_spec.cr
+++ b/spec/lucky_web/page_spec.cr
@@ -64,13 +64,13 @@ end
 describe LuckyWeb::Page do
   describe "tags that contain contents" do
     it "can be called with various arguments" do
-      view.header("text").to_s.should eq %(<header>\ntext\n</header> )
-      view.header("text", {class: "stuff"}).to_s.should eq %(<header class="stuff">\ntext\n</header> )
-      view.header("text", class: "stuff").to_s.should eq %(<header class="stuff">\ntext\n</header> )
+      view.header("text").to_s.should eq %(<header>text</header> )
+      view.header("text", {class: "stuff"}).to_s.should eq %(<header class="stuff">text</header> )
+      view.header("text", class: "stuff").to_s.should eq %(<header class="stuff">text</header> )
     end
 
     it "dasherizes attribute names" do
-      view.header("text", data_foo: "stuff").to_s.should eq %(<header data-foo="stuff">\ntext\n</header> )
+      view.header("text", data_foo: "stuff").to_s.should eq %(<header data-foo="stuff">text</header> )
     end
   end
 
@@ -85,7 +85,7 @@ describe LuckyWeb::Page do
 
   describe "HTML escaping" do
     it "escapes text" do
-      UnsafePage.new.render.to_s.should eq "\n&lt;script&gt;not safe&lt;/span&gt;\n"
+      UnsafePage.new.render.to_s.should eq "&lt;script&gt;not safe&lt;/span&gt;"
     end
 
     it "escapes HTML attributes" do
@@ -107,8 +107,8 @@ describe LuckyWeb::Page do
 
   describe "can be used to render layouts" do
     it "renders layouts" do
-      InnerPage.new.render.to_s.should contain %(<title>\nA great title\n</title>)
-      InnerPage.new.render.to_s.should contain %(<body>\nInner text\n</body>)
+      InnerPage.new.render.to_s.should contain %(<title>A great title</title>)
+      InnerPage.new.render.to_s.should contain %(<body>Inner text</body>)
     end
   end
 end

--- a/spec/lucky_web/page_spec.cr
+++ b/spec/lucky_web/page_spec.cr
@@ -64,22 +64,22 @@ end
 describe LuckyWeb::Page do
   describe "tags that contain contents" do
     it "can be called with various arguments" do
-      view.header("text").to_s.should eq %(<header>text</header> )
-      view.header("text", {class: "stuff"}).to_s.should eq %(<header class="stuff">text</header> )
-      view.header("text", class: "stuff").to_s.should eq %(<header class="stuff">text</header> )
+      view.header("text").to_s.should eq %(<header>text</header>)
+      view.header("text", {class: "stuff"}).to_s.should eq %(<header class="stuff">text</header>)
+      view.header("text", class: "stuff").to_s.should eq %(<header class="stuff">text</header>)
     end
 
     it "dasherizes attribute names" do
-      view.header("text", data_foo: "stuff").to_s.should eq %(<header data-foo="stuff">text</header> )
+      view.header("text", data_foo: "stuff").to_s.should eq %(<header data-foo="stuff">text</header>)
     end
   end
 
   describe "empty tags" do
     it "can be called with various arguments" do
-      view.br.to_s.should eq %(<br/> )
-      view.img(src: "my_src").to_s.should eq %(<img src="my_src"/> )
-      view.img({src: "my_src"}).to_s.should eq %(<img src="my_src"/> )
-      view.img({:src => "my_src"}).to_s.should eq %(<img src="my_src"/> )
+      view.br.to_s.should eq %(<br/>)
+      view.img(src: "my_src").to_s.should eq %(<img src="my_src"/>)
+      view.img({src: "my_src"}).to_s.should eq %(<img src="my_src"/>)
+      view.img({:src => "my_src"}).to_s.should eq %(<img src="my_src"/>)
     end
   end
 
@@ -91,9 +91,9 @@ describe LuckyWeb::Page do
     it "escapes HTML attributes" do
       unsafe = "<span>bad news</span>"
       escaped = "&lt;span&gt;bad news&lt;/span&gt;"
-      view.img(src: unsafe).to_s.should eq %(<img src="#{escaped}"/> )
-      view.img({src: unsafe}).to_s.should eq %(<img src="#{escaped}"/> )
-      view.img({:src => unsafe}).to_s.should eq %(<img src="#{escaped}"/> )
+      view.img(src: unsafe).to_s.should eq %(<img src="#{escaped}"/>)
+      view.img({src: unsafe}).to_s.should eq %(<img src="#{escaped}"/>)
+      view.img({:src => unsafe}).to_s.should eq %(<img src="#{escaped}"/>)
     end
   end
 

--- a/src/app/pages/tasks/index_page.cr
+++ b/src/app/pages/tasks/index_page.cr
@@ -13,7 +13,7 @@ class Tasks::IndexPage
 
   private def tasks_list
     ul do
-      tasks.each do |task|
+      @tasks.each do |task|
         li do
           a task.title, href: Tasks::Show.path(task.id)
         end

--- a/src/lucky_web/tags/base_tags.cr
+++ b/src/lucky_web/tags/base_tags.cr
@@ -56,7 +56,7 @@ module LuckyWeb::BaseTags
   {% end %}
 
   def text(content : String)
-    @view << HTML.escape(content) << " "
+    @view << "\n" << HTML.escape(content) << "\n"
   end
 
   private def build_tag_attrs(options)

--- a/src/lucky_web/tags/base_tags.cr
+++ b/src/lucky_web/tags/base_tags.cr
@@ -56,7 +56,7 @@ module LuckyWeb::BaseTags
   {% end %}
 
   def text(content : String)
-    @view << "\n" << HTML.escape(content) << "\n"
+    @view << HTML.escape(content)
   end
 
   private def build_tag_attrs(options)

--- a/src/lucky_web/tags/base_tags.cr
+++ b/src/lucky_web/tags/base_tags.cr
@@ -31,7 +31,7 @@ module LuckyWeb::BaseTags
       tag_attrs = build_tag_attrs(merged_options)
       @view << "<{{tag.id}}" << tag_attrs << ">"
       yield
-      @view << "</{{tag.id}}> "
+      @view << "</{{tag.id}}>"
     end
   end
 
@@ -51,7 +51,7 @@ module LuckyWeb::BaseTags
     def {{tag.id}}(options = EMPTY_HTML_ATTRS, **other_options)
       merged_options = merge_options(other_options, options)
       tag_attrs = build_tag_attrs(merged_options)
-      @view << %(<{{tag.id}}#{tag_attrs}/> )
+      @view << %(<{{tag.id}}#{tag_attrs}/>)
     end
   {% end %}
 


### PR DESCRIPTION
This replaces the text helpers trailing whitespace with a newline and
adds a leading newline to the content as well. This should make sure
HTML renders the way it's expected to render.

https://github.com/luckyframework/web/issues/114