### PR TITLE
Retry for a couple seconds if missing manifest

### DIFF
--- a/src/lucky_web/asset_helpers.cr
+++ b/src/lucky_web/asset_helpers.cr
@@ -2,4 +2,12 @@ module LuckyWeb::AssetHelpers
   ASSET_MANIFEST = {} of String => String
 
   {{ run "../run_macros/generate_asset_helpers" }}
+
+  macro asset(path)
+    {% if ASSET_MANIFEST[path] %}
+      {{ "/" + ASSET_MANIFEST[path] }}
+    {% else %}
+      {{ run "../run_macros/missing_asset", path }}
+    {% end %}
+  end
 end


### PR DESCRIPTION
Closes #139

When someone first clones a project, there is no public directory and
therefore no public/manifest.json. That means that when you first run
`lucky dev` from a newly cloned project it fails because the asset
helper complains about a missing manifest.

Now the asset helper will wait a couple seconds for
brunch/webpack/whatever to generate the manifest before raising. This
should be a better experience for new users, while still giving the user
a nice error message if the manifest isn't generated (like if
brunch/webpack failed to build).

Also need to set up sentry so when the manifest changes, the app is
rebuilt. That way the `asset` macro has the latest manifest.