### PR TITLE
Set document charset and lang on welcome page

### DIFF
--- a/src/lucky_web/welcome_page.cr
+++ b/src/lucky_web/welcome_page.cr
@@ -3,8 +3,9 @@ class LuckyWeb::WelcomePage
 
   render do
     html_doctype
-    html do
+    html lang: "en" do
       head do
+        utf8_charset
         title "Welcome to Lucky"
         load_lato_font
         normalize_styles


### PR DESCRIPTION
This sets the document charset on the welcome page and prevents the browser warning:
"The character encoding of the HTML document was not declared. The
document will render with garbled text in some browser configurations if
the document contains characters from outside the US-ASCII range. The
character encoding of the page must be declared in the document or in
the transfer protocol."