### PR TITLE
Show helpful error message when using `p`

### DIFF
--- a/src/lucky_web/page.cr
+++ b/src/lucky_web/page.cr
@@ -39,4 +39,14 @@ module LuckyWeb::Page
 
     generate_initializer
   end
+
+  macro p(_arg, **args)
+    {% raise <<-ERROR
+      `p` is not available on Lucky pages. This is because it's not clear whether you want to print something out or use a `p` HTML tag.
+      
+      Instead try:
+        * The `para` method if you want to use an HTML paragraph.
+        * The `pp` method to pretty print information for debugging.
+      ERROR %}
+  end
 end


### PR DESCRIPTION
There isn't a good reason to use `p` in a web page other than to debug something. So we should add a p macro to `LuckyWeb::Page` that accepts any number of arguments and let's the user know they should use para if they want a paragraph tag and pp if they want to debug. pp is better anyway because it also outputs the code that it's printing to standard out. It's super handy!

Fixes #143

<img width="1274" alt="screen shot 2017-10-27 at 16 33 29" src="https://user-images.githubusercontent.com/84148/32109301-9c73d668-bb34-11e7-9ac6-ce69f18dc781.png">

(I used the `BasePage` to verify locally that it works, like this:
```
  def render
    p "test"
  end
```
since I yet don't know how to build my own routes/controllers/view things. and excuse the Rails vocabular… that's what I am coming from…)