### PR TITLE
Fixes Yarn warning

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -38,7 +38,7 @@ module Sentry
 
     private def start_browser_sync
       spawn do
-        Process.run "yarn run browser-sync -- start -c bs-config.js",
+        Process.run "yarn run browser-sync start -c bs-config.js",
           output: true,
           error: true,
           shell: true
@@ -46,7 +46,7 @@ module Sentry
     end
 
     private def reload_browser_sync
-      Process.run "yarn run browser-sync -- reload",
+      Process.run "yarn run browser-sync reload",
         output: true,
         error: true,
         shell: true


### PR DESCRIPTION
From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.

