### PR TITLE
Fix JSON params parsing bug

### DIFF
--- a/spec/lucky_web/params_spec.cr
+++ b/spec/lucky_web/params_spec.cr
@@ -59,6 +59,16 @@ describe LuckyWeb::Params do
       params.get(:foo).should eq "bar"
     end
 
+    it "handles empty JSON body" do
+      request = build_request body: "",
+        content_type: "application/json"
+
+      params = LuckyWeb::Params.new(request)
+
+      # Should not raise
+      params.get(:anything)
+    end
+
     it "parses query params" do
       request = build_request body: "", content_type: ""
       request.query = "page=1&id=1"

--- a/src/lucky_web/params.cr
+++ b/src/lucky_web/params.cr
@@ -80,8 +80,14 @@ class LuckyWeb::Params
 
   @_parsed_json : JSON::Any?
 
-  private def parsed_json
-    @_parsed_json ||= JSON.parse(body)
+  private def parsed_json : JSON::Any
+    @_parsed_json ||= begin
+      if body.blank?
+        JSON.parse("{}")
+      else
+        JSON.parse(body)
+      end
+    end
   end
 
   private def body


### PR DESCRIPTION
Closes #180

If the body is empty, parse the params with `{}` so that there is no a
parse exception.