### PR TITLE
Fix redirect and response status

### DIFF
--- a/spec/lucky_web/response_spec.cr
+++ b/spec/lucky_web/response_spec.cr
@@ -1,0 +1,30 @@
+require "../spec_helper"
+
+include ContextHelper
+
+describe LuckyWeb::Response do
+  describe "#print" do
+    it "uses the default status if none is set" do
+      context = build_context
+      print_response(context, status: nil)
+      context.response.status_code.should eq LuckyWeb::Response::DEFAULT_STATUS
+    end
+
+    it "uses the passed in status" do
+      context = build_context
+      print_response(context, status: 300)
+      context.response.status_code.should eq 300
+    end
+
+    it "uses the response status if it's set, and LuckyWeb::Response status is nil" do
+      context = build_context
+      context.response.status_code = 300
+      print_response(context, status: nil)
+      context.response.status_code.should eq 300
+    end
+  end
+end
+
+private def print_response(context : HTTP::Server::Context, status : Int32?)
+  LuckyWeb::Response.new(context, "", "", status: status).print
+end

--- a/src/lucky_web/renderable.cr
+++ b/src/lucky_web/renderable.cr
@@ -42,11 +42,7 @@ module LuckyWeb::Renderable
     LuckyWeb::Response.new(context, content_type: "", body: "", status: status)
   end
 
-  private def json(body)
-    json(body, 200)
-  end
-
-  private def json(body, status : Int32)
+  private def json(body, status : Int32? = nil)
     LuckyWeb::Response.new(context, "application/json", body.to_json, status)
   end
 end

--- a/src/lucky_web/response.cr
+++ b/src/lucky_web/response.cr
@@ -1,12 +1,18 @@
 class LuckyWeb::Response
-  getter :context, :content_type, :body, :status
+  DEFAULT_STATUS = 200
 
-  def initialize(@context : HTTP::Server::Context, @content_type : String, @body : String, @status : Int32 = 200)
+  getter context, content_type, body
+
+  def initialize(@context : HTTP::Server::Context, @content_type : String, @body : String, @status : Int32? = nil)
   end
 
   def print
     context.response.content_type = content_type
     context.response.status_code = status
     context.response.print body
+  end
+
+  def status
+    @status || context.response.status_code || DEFAULT_STATUS
   end
 end


### PR DESCRIPTION
Close #187

The problem was that you were forced to pass a status to response, so if
you set the status code on the context and then printed a
`LuckyWeb::Response` the original status would be overwritten.

This changes it so that the status can be `nil` on `LuckyWeb::Response`
and it defaults to the one already set on the context, or lastly
defaults to 200.
