### PR TITLE
Add checkbox input helper

### DIFF
--- a/spec/lucky_web/input_helpers_spec.cr
+++ b/spec/lucky_web/input_helpers_spec.cr
@@ -36,6 +36,20 @@ describe LuckyWeb::InputHelpers do
     HTML
   end
 
+  it "renders checkbox inputs" do
+    view.checkbox(form.first_name, value: "1").to_s.should contain <<-HTML
+    <input type="checkbox" name="user:first_name" value="1"/>
+    HTML
+
+    view.checkbox(form.first_name, value: "1", class: "cool").to_s.should contain <<-HTML
+    <input type="checkbox" name="user:first_name" value="1" class="cool"/>
+    HTML
+
+    view.checkbox(form.first_name, value: "1").to_s.should have_unchecked_value("0")
+
+    view.checkbox(form.first_name, unchecked_value: "not_accepted").to_s.should have_unchecked_value("not_accepted")
+  end
+
   it "renders text inputs" do
     view.text_input(form.first_name).to_s.should contain <<-HTML
     <input type="text" name="user:first_name" value="My name"/>
@@ -153,4 +167,10 @@ end
 
 private def view
   TestPage.new
+end
+
+private def have_unchecked_value(value)
+  contain <<-HTML
+  <input type="hidden" name="user:first_name" value="#{value}" id=""/>
+  HTML
 end

--- a/src/lucky_web/tags/input_helpers.cr
+++ b/src/lucky_web/tags/input_helpers.cr
@@ -9,6 +9,12 @@ module LuckyWeb::InputHelpers
     })
   end
 
+  def checkbox(field : LuckyRecord::AllowedField, **html_options, unchecked_value : String? = nil)
+    hidden_value = unchecked_value || "0"
+    generate_input(field, "hidden", {"id" => ""}, {"value" => hidden_value})
+    generate_input(field, "checkbox", html_options)
+  end
+
   def text_input(field : LuckyRecord::AllowedField, **html_options)
     generate_input(field, "text", html_options)
   end


### PR DESCRIPTION
This is inspired by the Rails and SimpleForm checkbox helpers. There
will always be a hidden field, that transmits the unchecked value.
Otherwise the form would just omit the value, if the checkbox isn't
checked. If the user provides a value for `unchecked_value` we just use
that one. If none given it defaults to "0".

Closes #19