### PR TITLE
Introduce LuckyWeb::AllowedInTags for HTML tags

### DIFF
--- a/spec/lucky_web/base_tags_spec.cr
+++ b/spec/lucky_web/base_tags_spec.cr
@@ -7,9 +7,23 @@ private class TestPage
   end
 end
 
+class MySpecialClass
+  include LuckyWeb::AllowedInTags
+
+  def to_s
+    "it works"
+  end
+end
+
 describe LuckyWeb::BaseTags do
   it "renders para tag as <p>" do
     view.para("foo").to_s.should contain "<p>foo</p>"
+  end
+
+  it "renders allowed types in tags" do
+    view.para(42).to_s.should contain "<p>42</p>"
+    view.para(MySpecialClass.new).to_s.should contain "<p>it works</p>"
+    view.para(1_i64).to_s.should contain "<p>1</p>"
   end
 end
 

--- a/src/charms/int32_extensions.cr
+++ b/src/charms/int32_extensions.cr
@@ -1,0 +1,5 @@
+require "../lucky_web/allowed_in_tags"
+
+struct Int32
+  include LuckyWeb::AllowedInTags
+end

--- a/src/charms/int64_extensions.cr
+++ b/src/charms/int64_extensions.cr
@@ -1,0 +1,5 @@
+require "../lucky_web/allowed_in_tags"
+
+struct Int64
+  include LuckyWeb::AllowedInTags
+end

--- a/src/lucky_web/allowed_in_tags.cr
+++ b/src/lucky_web/allowed_in_tags.cr
@@ -1,0 +1,2 @@
+module LuckyWeb::AllowedInTags
+end

--- a/src/lucky_web/tags/base_tags.cr
+++ b/src/lucky_web/tags/base_tags.cr
@@ -14,7 +14,7 @@ module LuckyWeb::BaseTags
       end
     end
 
-    def {{method_name.id}}(content : String)
+    def {{method_name.id}}(content : String | LuckyWeb::AllowedInTags)
       {{method_name.id}}(EMPTY_HTML_ATTRS) do
         text content
       end
@@ -55,8 +55,8 @@ module LuckyWeb::BaseTags
     end
   {% end %}
 
-  def text(content : String)
-    @view << HTML.escape(content)
+  def text(content : String | LuckyWeb::AllowedInTags)
+    @view << HTML.escape(content.to_s)
   end
 
   private def build_tag_attrs(options)


### PR DESCRIPTION
Until now we only did allow Strings for content in HTML tags. Since
people do want to write Int32s and Int64 (and potentially other types as
well) to HTML, we created a new module called `LuckyWeb::AllowedInTags`.

This type is allowed for HTML tags and will be written to HTML with
`to_s`.

Closes #192