### PR TITLE
Generate page initializer on "finished"

### DIFF
--- a/spec/lucky_web/html_page_spec.cr
+++ b/spec/lucky_web/html_page_spec.cr
@@ -49,8 +49,11 @@ abstract class MainLayout
 end
 
 class InnerPage < MainLayout
+  needs foo : String
+
   def inner
     text "Inner text"
+    text @foo
   end
 
   def page_title
@@ -103,9 +106,9 @@ describe LuckyWeb::HTMLPage do
   end
 
   describe "can be used to render layouts" do
-    it "renders layouts" do
-      InnerPage.new.render.to_s.should contain %(<title>A great title</title>)
-      InnerPage.new.render.to_s.should contain %(<body>Inner text</body>)
+    it "renders layouts and needs" do
+      InnerPage.new(foo: "bar").render.to_s.should contain %(<title>A great title</title>)
+      InnerPage.new(foo: "bar").render.to_s.should contain %(<body>Inner textbar</body>)
     end
   end
 end

--- a/src/lucky_web/html_page.cr
+++ b/src/lucky_web/html_page.cr
@@ -12,13 +12,33 @@ module LuckyWeb::HTMLPage
   include LuckyWeb::Assignable
   include LuckyWeb::AssetHelpers
 
-  macro generate_initializer
-    def initialize(
-      {% for var, type in ASSIGNS %}
-        @{{ var }} : {{ type }},
-      {% end %}
-      )
+  macro setup_initializer_hook
+    macro finished
+      generate_needy_initializer
     end
+
+    macro included
+      setup_initializer_hook
+    end
+
+    macro inherited
+      setup_initializer_hook
+    end
+  end
+
+  macro included
+    setup_initializer_hook
+  end
+
+  macro generate_needy_initializer
+    {% if !@type.abstract? %}
+      def initialize(
+        {% for var, type in ASSIGNS %}
+          @{{ var }} : {{ type }},
+        {% end %}
+        )
+      end
+    {% end %}
   end
 
   macro render
@@ -26,8 +46,6 @@ module LuckyWeb::HTMLPage
       {{ yield }}
       @view
     end
-
-    generate_initializer
   end
 
   macro p(_arg, **args)


### PR DESCRIPTION
Closes #206

This makes it work correctly with layouts. It will also allow using a
regular `render` method instead of the `render` macro with a block.