### PR TITLE
Add ISO 8601 timestamp to request log

### DIFF
--- a/spec/lucky_web/log_handler_spec.cr
+++ b/spec/lucky_web/log_handler_spec.cr
@@ -16,6 +16,7 @@ describe LuckyWeb::LogHandler do
     log_output.should contain("GET")
     log_output.should contain("200")
     log_output.should contain("/")
+    log_output.should_not match(/#{Time.now.to_s("%Y-%m-%d")}/)
     called.should be_true
   end
 
@@ -41,6 +42,7 @@ describe LuckyWeb::LogHandler do
     end
     log_output = log_io.to_s
     log_output.should contain("GET")
+    log_output.should_not match(/#{Time.now.to_s("%Y-%m-%d")}/)
     log_output.should contain("Unhandled exception:")
   end
 

--- a/spec/lucky_web/log_handler_spec.cr
+++ b/spec/lucky_web/log_handler_spec.cr
@@ -43,6 +43,32 @@ describe LuckyWeb::LogHandler do
     log_output.should contain("GET")
     log_output.should contain("Unhandled exception:")
   end
+
+  context "when configured to log timestamps" do
+    it "logs timestamp" do
+      begin
+        LuckyWeb::LogHandler.configure do
+          settings.show_timestamps = true
+        end
+
+        io = IO::Memory.new
+        called = false
+        log_io = IO::Memory.new
+        context = build_context_with_io(io)
+
+        call_log_handler_with(log_io, context) { called = true }
+
+        log_output = log_io.to_s
+        log_output.should contain("GET")
+        log_output.should match(/#{Time.now.to_s("%Y-%m-%d")}/)
+        called.should be_true
+      ensure
+        LuckyWeb::LogHandler.configure do
+          settings.show_timestamps = false
+        end
+      end
+    end
+  end
 end
 
 private def call_log_handler_with(io : IO, context : HTTP::Server::Context, &block)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -19,4 +19,8 @@ LuckyWeb::ErrorHandler.configure do
   settings.show_debug_output = false
 end
 
+LuckyWeb::LogHandler.configure do
+  settings.show_timestamps = false
+end
+
 Habitat.raise_if_missing_settings!

--- a/src/lucky_web/log_handler.cr
+++ b/src/lucky_web/log_handler.cr
@@ -46,8 +46,8 @@ class LuckyWeb::LogHandler
   end
 
   private def timestamp(time)
-    if settings.show_timestamps && time
-      " #{Time::Format::ISO_8601_DATE_TIME.format(time)}"
+    if settings.show_timestamps
+      " #{Time::Format::ISO_8601_DATE_TIME.format(time || Time.now)}"
     else
       ""
     end

--- a/src/lucky_web/log_handler.cr
+++ b/src/lucky_web/log_handler.cr
@@ -16,18 +16,12 @@ class LuckyWeb::LogHandler
     elapsed = Time.now - time
     elapsed_text = elapsed_text(elapsed)
 
-    timestamp = if settings.show_timestamps
-                  Time::Format::ISO_8601_DATE_TIME.format(time)
-                else
-                  ""
-                end
-
-    @io.puts "#{context.request.method} #{context.response.status_code} #{context.request.resource.colorize(:green)} #{timestamp} (#{elapsed_text})"
+    @io.puts "#{context.request.method} #{context.response.status_code} #{context.request.resource.colorize(:green)}#{timestamp(time)} (#{elapsed_text})"
     {% if !flag?(:release) %}
       log_debug_messages(context)
     {% end %}
   rescue e
-    @io.puts "#{context.request.method} #{context.request.resource} #{timestamp} - Unhandled exception:"
+    @io.puts "#{context.request.method} #{context.request.resource}#{timestamp(time)} - Unhandled exception:"
     e.inspect_with_backtrace(@io)
     raise e
   end
@@ -49,5 +43,13 @@ class LuckyWeb::LogHandler
     return "#{millis.round(2)}ms" if millis >= 1
 
     "#{(millis * 1000).round(2)}µs"
+  end
+
+  private def timestamp(time)
+    if settings.show_timestamps && time
+      " #{Time::Format::ISO_8601_DATE_TIME.format(time)}"
+    else
+      ""
+    end
   end
 end


### PR DESCRIPTION
Closes #210 

Example when enabled: 
```
GET 200 /? 2017-11-13T15:12:10+0100 (372.0µs)
   ▸ Handled by Home::Index
   ▸ Rendered LuckyWeb::WelcomePage
GET 404 /favicon.ico? 2017-11-13T15:12:10+0100 (137.0µs)
```