### PR TITLE
Fine tune hash "get!" specs

### DIFF
--- a/spec/charms/hash_spec.cr
+++ b/spec/charms/hash_spec.cr
@@ -25,14 +25,14 @@ describe "Hash charm" do
       hash.get!("foo").should eq "bar"
     end
 
-    it "returns nil if the key is missing" do
+    it "raises KeyError if the key is missing" do
       hash = {"foo" => "bar"}
 
       expect_raises(KeyError) do
-        hash.get!(:missing).should be_nil
+        hash.get!(:missing)
       end
       expect_raises(KeyError) do
-        hash.get!("missing").should eq be_nil
+        hash.get!("missing")
       end
     end
   end


### PR DESCRIPTION
Fix copy-pasted it-description and remove unneeded expectation inside expectation.
I didn't actually run this (shame on me) but the `.should be_nil` inside the `expect_raises` seems unneeded and confused me for a second.